### PR TITLE
chore(release):  version 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/.stfolder
 **/.vscode
-build/cmake/**/
-build/cmake/**/*.*
+build/cmake/**
+build/cmake/*.*
 build/**/.vs
 build/**/*.user
 build/**/*.suo

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
     CLIF::FApplication app("科学计算工具");
 
     /// 注册容器类型
-    app.addNewContainerConverter<vector<vector<int>>>();
+    app.registerContainerConverter<vector<vector<int>>>();
 
     /// 链接子命令和功能函数及带验证器的命令参数
     app.addSubCommand("matrix", "处理二维矩阵",

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 ## 为什么选择CLIF？
 
 ✅ **单文件依赖** \
- : 仅依赖C++17标准库, 无需任何外部依赖
+ ：仅依赖C++17标准库, 无需任何外部依赖
 
 ✅ **函数式编程** \
- : 命令直接绑定到函数，避免手动解析参数
+ ：命令直接绑定到函数，避免手动解析参数
 
 ✅ **强类型安全** \
- : 构建期捕获类型冲突，避免运行时错误
+ ：构建期捕获类型冲突，避免运行时错误
 
 ✅ **泛容器支持** \
  ：原生支持嵌套容器，支持自定义解析器和验证器
@@ -70,7 +70,7 @@ CLIF充分利用了C++17的**类型推断**和**函数式编程**等特性，为
 > [!NOTE]
 > 注意：这里的示例代码是为了便于说明，你可以根据自己的项目结构进行调整。
 
-#### 步骤1: 引入CLIF
+#### 步骤1：引入CLIF
 
 在入口文件中引入CLIF头文件，确保编译器启用C++17或更高标准：
 ```cpp
@@ -78,7 +78,7 @@ CLIF充分利用了C++17的**类型推断**和**函数式编程**等特性，为
 #include <CLIF/CLIF.hpp>
 ```
 
-#### 步骤2: 定义功能函数
+#### 步骤2：定义功能函数
 
 功能函数是用户自定义的、返回值为void的函数集合，它们将被绑定到CLIF中执行。用户可以根据实际需求灵活定义任意参数类型和参数数量。通常，`funcs.hpp`头文件用于集中管理用户实现的功能函数逻辑。
 
@@ -92,7 +92,7 @@ void matrix_op(vector<vector<int>> matrix) {
 }
 ```
 
-#### 步骤3: 构建CLIF接口
+#### 步骤3：构建CLIF接口
 
 CLIF通过命令解析器解析用户输入，根据命令名称和参数匹配功能函数。用户需要在入口源文件中注册命令和功能函数的绑定关系。
 
@@ -143,10 +143,10 @@ int main(int argc, char *argv[])
 ```bash
 ./app.exe --log-file <log-file-path> --log-level <log-level>
 ```
-• 默认日志文件: `<app-name>.log`
-• 日志级别对应: `1:info`, `2:warn`, `3:error`, `4:fatal`
+• 默认日志文件：`<app-name>.log`
+• 日志级别对应：`1:info`, `2:warn`, `3:error`, `4:fatal`
 
-#### 步骤5: 运行用户命令
+#### 步骤5：运行用户命令
 
 ```bash
 ./app.exe matrix --data "[1,2],[3,4]"
@@ -157,9 +157,9 @@ int main(int argc, char *argv[])
 ## 需要帮助？
 ## 联系我
 
-- **维护**: [KenanZhu (Nanoki)](https://github.com/KenanZhu)
-- **邮箱**: <nanoki_zh@163.com>
-- **讨论**: 提交[Issues](https://github.com/KenanZhu/CLIF/issues)或[PR](https://github.com/KenanZhu/CLIF/pulls)
+- **维护**：[KenanZhu (Nanoki)](https://github.com/KenanZhu)
+- **邮箱**：<nanoki_zh@163.com>
+- **讨论**：提交[Issues](https://github.com/KenanZhu/CLIF/issues)或[PR](https://github.com/KenanZhu/CLIF/pulls)
 ---
 
 _**Free to use** —— CLIF_

--- a/autobuild.bat
+++ b/autobuild.bat
@@ -1,23 +1,38 @@
+::
+:: Batch script to automatically build CLIF example on Windows.
+::
 @echo off
 setlocal enabledelayedexpansion
 
 :: Directories.
+::------------------------------------------------------------------------------
 set "ROOT_DIR=%~dp0"
 set "SRC_DIR=%ROOT_DIR%src"
 set "BUILD_DIR=%ROOT_DIR%build\cmake"
 set "BIN_DIR=%BUILD_DIR%\bin\CLIF_example"
 
-:: Create build directory if needed.
+:: Create default build directory.
+echo autobuild : Checking default build directory...
+::------------------------------------------------------------------------------
+
 if not exist "%BUILD_DIR%" (
-    echo Creating build directory: "%BUILD_DIR%"
-    mkdir "%BUILD_DIR%"
+    mkdir "%BUILD_DIR%" || (
+        echo autobuild : Error * Failed to create default build directory: "%BUILD_DIR% ."
+        pause
+        exit /b 1
+    )
 )
+
+:: Check CMake environment.
+echo autobuild : Checking CMake environment...
+::------------------------------------------------------------------------------
 
 :: Check CMake existence.
 where cmake >nul 2>&1
 if %errorlevel% neq 0 (
-    echo ERROR: CMake not found in PATH.
-    echo Please install CMake 3.10+ from: https://cmake.org/download/
+    echo autobuild : Error * CMake not found in PATH.
+    echo autobuild : Please install CMake 3.12+ from:
+    echo           - https://cmake.org/download/
     pause
     exit /b 1
 )
@@ -28,58 +43,63 @@ for /f "tokens=3" %%a in ('cmake --version 2^>^&1 ^| findstr /r /c:"[0-9][0-9]*\
 )
 for /f "tokens=1-3 delims=." %%a in ("%version%") do (
     if %%a lss 3 (
-        echo ERROR: Requires CMake 3.10+, found version %version%
+        echo ERROR: Requires CMake 3.12+, found version %version% .
         pause
         exit /b 1
     )
-    if %%a equ 3 if %%b lss 10 (
-        echo ERROR: Requires CMake 3.10+, found version %version%
+    if %%a equ 3 if %%b lss 12 (
+        echo ERROR: Requires CMake 3.12+, found version %version% .
         pause
         exit /b 1
     )
 )
 
-:: Build process.
+:: Auto build process.
+echo autobuild : All required tools found. Starting auto build process...
+::-----------------------------------------------------------------------------
+
+echo autobuild : Generating build system...
 cd /d "%BUILD_DIR%"
-echo Generating build system...
-cmake "%SRC_DIR%"
+cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug "%SRC_DIR%"
 if %errorlevel% neq 0 (
-    echo CMake generation failed!
+    echo autobuild : Error * CMake generation failed !
+    pause
+    exit /b 1
+)
+cmake --build . --config Debug
+if %errorlevel% neq 0 (
+    echo autobuild : Error * Build failed !
     pause
     exit /b 1
 )
 
-echo Compiling project...
-cmake --build .
-if %errorlevel% neq 0 (
-    echo Build failed!
-    pause
-    exit /b 1
-)
+:: Auto build success message.
+echo autobuild :
+echo     BUILD SUCCESSFUL !
+echo     Executables located at:
+echo         "%BIN_DIR%"
 
-:: Success message.
-echo --------------------------------------------------
-echo BUILD SUCCESSFUL
-echo Executables located at: 
-echo   "%BIN_DIR%"
-echo --------------------------------------------------
+:: Start PowerShell in target directory
+echo autobuild : Starting new PowerShell instance in target directory...
+::-----------------------------------------------------------------------------
 
-:: Start PowerShell in target directory with error handling.
 if exist "%BIN_DIR%" (
-    echo Starting PowerShell in target directory...
+    echo autobuild : Starting PowerShell in target directory...
     start "" powershell -NoExit -Command "Set-Location -LiteralPath '%BIN_DIR:\=\\%'; Write-Host 'You are now in the build directory' -ForegroundColor Green"
 ) else (
-    echo WARNING: Build directory not found at:
+    echo autobuild : Warning * Build directory not found at:
     echo   "%BIN_DIR%"
-    echo Launching PowerShell in build folder instead
+    echo Launching PowerShell in build folder instead.
     start "" powershell -NoExit -Command "Write-Host 'Build directory not found at expected location' -ForegroundColor Yellow"
 )
 
-:: Keep CMD window open after PowerShell starts.
-echo --------------------------------------------------
-echo Batch script completed. PowerShell window is open.
-echo This window will remain active until you close it.
-echo --------------------------------------------------
+:: End of script.
+echo autobuild : Auto build process completed.
+::------------------------------------------------------------------------------
+
+echo autobuild :
+echo     Batch script completed. PowerShell window is open.
+echo     This window will remain active until you close it.
 pause
 
 endlocal

--- a/autobuild.sh
+++ b/autobuild.sh
@@ -1,61 +1,79 @@
-#!/bin/bash
+#
+# Shell script to automatically build CLIF example on Linux.
+#
 
 # Directories
+#------------------------------------------------------------------------------
 ROOT_DIR=$(dirname "$(realpath "$0")")
 SRC_DIR="$ROOT_DIR/src"
 BUILD_DIR="$ROOT_DIR/build/cmake"
-BIN_DIR="$BUILD_DIR/bin/CLIF_example/Debug"
+BIN_DIR="$BUILD_DIR/bin/CLIF_example"
 
-# Create build directory if needed
+# Check default build directory.
+echo "autobuild : Checking default build directory..."
+#------------------------------------------------------------------------------
+
 mkdir -p "$BUILD_DIR" || {
-    echo "Error: Failed to create build directory: $BUILD_DIR"
+    echo "autobuild : Error * Failed to create default build directory: $BUILD_DIR ."
     exit 1
 }
 
-# Check CMake existence
+# Check CMake environment.
+echo "autobuild : Checking CMake environment..."
+#------------------------------------------------------------------------------
+
+# Check CMake existence.
 if ! command -v cmake &> /dev/null; then
-    echo "ERROR: CMake not found in PATH."
-    echo "Please install CMake 3.10+ with:"
-    echo "  sudo apt install cmake    # Debian/Ubuntu"
-    echo "  sudo yum install cmake    # RHEL/CentOS"
+    echo "autobuild : Error * CMake not found in PATH."
+    echo "autobuild : Please install CMake 3.10+ with:"
+    echo "          - sudo apt install cmake    # Debian/Ubuntu"
+    echo "          - sudo yum install cmake    # RHEL/CentOS"
     exit 1
 fi
 
-# Check CMake version
-CMAKE_VERSION=$(cmake --version | awk 'NR==1{print $3}')
-MIN_VERSION="3.10"
+# Check CMake version.
+CURRENT_CMAKE_VERSION=$(cmake --version | awk 'NR==1{print $3}')
+REQUIRE_CMAKE_VERSION="3.12"
 
-if printf '%s\n' "$MIN_VERSION" "$CMAKE_VERSION" | sort -V -C; then
+if printf '%s\n' "$REQUIRE_CMAKE_VERSION" "$CURRENT_CMAKE_VERSION" | sort -V -C; then
     :
 else
-    echo "ERROR: Requires CMake $MIN_VERSION+, found version $CMAKE_VERSION"
+    echo "autobuild : Error * Requires CMake $REQUIRE_CMAKE_VERSION+, found version $CURRENT_CMAKE_VERSION ."
     exit 1
 fi
 
-# Build process
-cd "$BUILD_DIR" || exit 1
-echo "Generating build system..."
+# Auto build process.
+echo "autobuild : All required tools found. Starting auto build process..."
+#------------------------------------------------------------------------------
+
+# Auto generate build system.
+echo "autobuild : Generating build system..."
+cd "$BUILD_DIR" || {
+    echo "autobuild : Error * Failed to access directory: $BUILD_DIR"
+    exit 1
+}
 cmake "$SRC_DIR" || {
-    echo "CMake generation failed!"
+    echo "autobuild : CMake generation failed !"
     exit 1
 }
-
-echo "Compiling project..."
 cmake --build . || {
-    echo "Build failed!"
+    echo "autobuild : Error * Build failed !"
     exit 1
 }
 
-# Success message
-echo "--------------------------------------------------"
-echo "BUILD SUCCESSFUL"
-echo "Executables located at:"
-echo "  \"$BIN_DIR\""
-echo "--------------------------------------------------"
+# Auto build success message.
+echo "autobuild :"
+echo "    AUTO BUILD SUCCESSFUL !"
+echo "    Executables located at:"
+echo "        \"$BIN_DIR\""
+echo ""
+#------------------------------------------------------------------------------
 
-# Start terminal in target directory
+# Start terminal in target directory.
+echo "autobuild : Starting new terminal in target directory..."
+#------------------------------------------------------------------------------
+
 if [ -d "$BIN_DIR" ]; then
-    echo "Starting new terminal in target directory..."
     # Try different terminal emulators (fallback to default)
     if command -v x-terminal-emulator &> /dev/null; then
         x-terminal-emulator --working-directory="$BIN_DIR" &
@@ -66,15 +84,19 @@ if [ -d "$BIN_DIR" ]; then
     elif command -v xterm &> /dev/null; then
         xterm -e "cd \"$BIN_DIR\"; bash" &
     else
-        echo "WARNING: No terminal emulator found. Manually navigate to:"
+        echo "autobuild : Warning * No terminal emulator found. Manually navigate to:"
         echo "  cd \"$BIN_DIR\""
     fi
 else
-    echo "WARNING: Build directory not found at:"
-    echo "  \"$BIN_DIR\""
+    echo "autobuild : Warning * Build directory not found at:"
+    echo "    \"$BIN_DIR\""
 fi
 
-echo "--------------------------------------------------"
-echo "Batch script completed. PowerShell window is open."
-echo "This window will remain active until you close it."
-echo "--------------------------------------------------"
+# End of script.
+echo "autobuild : Auto build process completed."
+#------------------------------------------------------------------------------
+
+echo "autobuild :"
+echo "    Batch script completed. Terminal window is open."
+echo "    This window will remain active until you close it."
+echo ""

--- a/doc/readme_en/README.md
+++ b/doc/readme_en/README.md
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     CLIF::FApplication app("Scientific Computing Tool");
 
     /// Register container type
-    app.addNewContainerConverter<vector<vector<int>>>();
+    app.registerContainerConverter<vector<vector<int>>>();
 
     /// Bind subcommand with validated parameters
     app.addSubCommand("matrix", "Process a two-dimensional matrix",

--- a/doc/readme_en/README.md
+++ b/doc/readme_en/README.md
@@ -5,16 +5,16 @@ English | [简体中文](../../README.md)
 ---
 ## Why Choose CLIF?
 
-✅ **Single File Dependency**
+✅ **Single File Dependency** \
  : Requires only the C++17 standard library with no external dependencies
 
-✅ **Functional Programming**
+✅ **Functional Programming** \
  : Direct function binding eliminates manual argument parsing
 
-✅ **Strong Type Safety**
+✅ **Strong Type Safety** \
  : Catches type conflicts during compilation to prevent runtime errors
 
-✅ **Generic Container Support**
+✅ **Generic Container Support** \
  : Native support for nested containers with custom parsers and validators
 
 CLIF leverages C++17 features like **type inference** and **functional programming** to provide robust type safety and generic container support for command-line applications.
@@ -28,7 +28,7 @@ The [example directory](../../src/example/) contains a complete CLIF implementat
 Build using either method:
 
 <details>
-<summary>Using VS2022:</summary>
+<summary>Using VS2022: </summary>
 
 1. Open VS2022 and load the solution file: [CLIF_Example.sln](../../build/vs/CLIF_Example/CLIF_Example.sln) in the [VS solution directory](../../build/vs/)
 2. Build the solution
@@ -36,7 +36,7 @@ Build using either method:
 </details>
 
 <details>
-<summary>CMake build for Cross-platform:</summary>
+<summary>CMake build for Cross-platform: </summary>
 
 1. Install CMake (3.10+) on Windows or Linux
 2. In terminal at [CMAKE build directory](../../build/cmake/):

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -307,7 +307,8 @@ splitIfExist(const std::vector<std::string> &vec,
 std::string CLIF::FStr::
 formatByCols(const std::string &strL,
              const std::string &strR,
-             const int widthL, const int widthR)
+             const int widthL,
+             const int widthR)
 {
     size_t target, last, next;
     std::string temp_strL, temp_strR, res;

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -950,10 +950,9 @@ tryToNormOptionSyntax(void)
     std::vector<std::string> t_rest_cmdline;
 
     for (auto &section : _unparsed_cmdline) {
-        i = section.find('=');
-        if (i != std::string::npos) {
-            t_rest_cmdline.push_back(section.substr(0, i));
-            t_rest_cmdline.push_back(section.substr(i + 1));
+        if (section.find('=') != std::string::npos) {
+            auto it = CLIF::FStr::splitBy(section, '=');
+            t_rest_cmdline.insert(t_rest_cmdline.end(), it.begin(), it.end());
         } else {
             t_rest_cmdline.push_back(section);
         }

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -258,19 +258,17 @@ splitKeyValue(const std::string &str, const std::string &delimiter)
 }
 
 std::vector<std::vector<std::string>> CLIF::FStr::
-splitIfExist(const std::vector<std::string> &vec,
-             const std::set<std::string> &check_set)
+splitIf(const std::vector<std::string> &vec,
+        const std::function<bool(const std::string &)> &condition)
 {
-    bool active_group;
+    bool active_group = false;
     std::vector<std::string> current_group;
     std::vector<std::vector<std::string>> split_groups;
 
-    active_group = false;
-
     for (const auto &s : vec) {
-        if (check_set.count(s)) {
+        if (condition(s)) {
             if (active_group) {
-                split_groups.push_back(current_group);
+                split_groups.push_back(std::move(current_group));
                 current_group.clear();
             }
             current_group.push_back(s);
@@ -279,9 +277,21 @@ splitIfExist(const std::vector<std::string> &vec,
             current_group.push_back(s);
         }
     }
-    if (active_group) split_groups.push_back(current_group);
-
+    if (active_group) {
+        split_groups.push_back(std::move(current_group));
+    }
     return split_groups;
+}
+
+std::vector<std::vector<std::string>> CLIF::FStr::
+splitIfExist(const std::vector<std::string> &vec,
+             const std::set<std::string> &check_set)
+{
+    return CLIF::FStr::splitIf(vec,
+    [&check_set](const std::string &s)
+    {
+        return check_set.count(s);
+    });
 }
 
 std::vector<std::vector<std::string>> CLIF::FStr::
@@ -966,57 +976,113 @@ generateGlobalHelp(const std::map<std::string, CLIF::Wrapper> &func_linkers)
 }
 
 void CLIF::FParser::
-tryToNormOptionSyntax(void)
+normalizeOptionGroupEquals(std::vector<std::string> &option_group)
 {
     size_t i;
-    std::vector<std::string> t_rest_cmdline;
+    std::vector<std::string> t_group;
 
-    for (auto &section : _unparsed_cmdline) {
+    for (auto &section : option_group) {
         if (section.find('=') != std::string::npos) {
             auto it = CLIF::FStr::splitBy(section, '=');
-            t_rest_cmdline.insert(t_rest_cmdline.end(), it.begin(), it.end());
+            t_group.insert(t_group.end(), it.begin(), it.end());
         } else {
-            t_rest_cmdline.push_back(section);
+            t_group.push_back(section);
         }
     }
-    _unparsed_cmdline = std::move(t_rest_cmdline);
+    option_group = std::move(t_group);
+}
+
+/**
+    \note :
+    This function will normalize short option groups.
+
+    We regard the first section of each option group as the option name,
+    and the rest sections as the arguments of the option. Each short option
+    character will sequentially take one argument until all arguments
+    are exhausted. Any remaining short options will then be treated as
+    options without arguments. Conversely, if arguments still remain,
+    all of them will be appended to the last option.
+
+    For example short option groups like {"-X", "arg"} or {"-XY", "arg"},
+    they will be normalized to {"-X", "arg"} and {"-X", "arg"} ,{"-Y"}.
+
+    For this reason, general GNU/POSIX short option "-ofile" will not regard
+    as {"-o", "file"}.
+ */
+void CLIF::FParser::
+normlizeShortOptionGroups(void)
+{
+    bool has_param;
+    size_t i, j, opt_num, arg_num;
+    std::string opt_chars;
+    std::vector<std::string> new_group, rest_args;
+    std::vector<std::vector<std::string>> new_groups;
+
+    has_param = false;
+
+    for (auto &group : _parsed_options_groups) {
+        if (group.empty()) continue;
+        if (group[0].find("--") == 0) {
+            new_groups.push_back(group);
+            continue;
+        }
+        /// We already know each begin of group all is start with '-'.
+        if (group[0].size() <= 2) {
+            new_groups.push_back(group);
+            continue;
+        }
+
+        opt_chars = group[0].substr(1);
+        opt_num = opt_chars.size();
+        arg_num = group.size() - 1;
+
+        for (i = 0; i < opt_num; ++i) {
+            new_group.clear();
+            new_group.push_back(std::string("-") + opt_chars[i]);
+            if (i < opt_num - 1) {
+                if (i < arg_num) {
+                    new_group.push_back(group[1 + i]);
+                }
+            }
+            else if (arg_num > i) {
+                for (j = 1 + i; j < group.size(); ++j) {
+                    new_group.push_back(group[j]);
+                }
+            }
+            new_groups.push_back(new_group);
+        }
+    }
+    _parsed_options_groups = std::move(new_groups);
 }
 
 void CLIF::FParser::
-tryToAutoMatchOptions(void)
+normalizeOptionGroups(void)
 {
-    /**
-        Only all options only own one argument, this will
-        regard each input is sort by given options vector.
-
-        But, we have plan to support positional arguments in the future.
-     */
-    size_t i, idx, opts_amount;
-    std::vector<std::string> auto_matched, long_opts_name;
-
-    i = 0;
-    opts_amount = 0;
-
-    for (const auto &option : _active_wrapper.options) {
-        if (option.getNumOfArgs() != 1) return;
-
-        opts_amount += option.getNumOfArgs();
-        long_opts_name.push_back(option.getLongName());
+    for (auto &group : _parsed_options_groups) {
+        if (group.empty()) continue;
+        if (group[0] == "--") break;
+        this->normalizeOptionGroupEquals(group);
     }
+    this->normlizeShortOptionGroups();
+}
 
-    for (const auto &section : _unparsed_cmdline) {
-        if (!_active_options.count(section)) i++;
-    }
+bool CLIF::FParser::
+validateUnknownOptions(void)
+{
+    bool valid;
 
-    if (i == opts_amount && _unparsed_cmdline.size() == opts_amount) {
-        auto_matched.reserve(long_opts_name.size() + _unparsed_cmdline.size());
+    valid = true;
 
-        for (idx = 0; idx < long_opts_name.size(); ++idx) {
-            auto_matched.push_back(long_opts_name[idx]);
-            auto_matched.push_back(_unparsed_cmdline[idx]);
+    for (const auto &group : _parsed_options_groups) {
+        if (_active_options.count(group[0]) == 0) {
+            CLIF::FStdo::
+            runMsg("got unknown [options] '"
+                + group[0]
+                + "'.", 2);
+            valid = false;
         }
-        _unparsed_cmdline = std::move(auto_matched);
     }
+    return valid;
 }
 
 bool CLIF::FParser::
@@ -1159,13 +1225,18 @@ validateOptionsSyntax(void)
         _active_options.insert(option.getLongName());
         _active_options.insert(option.getShortName());
     }
-    this->tryToNormOptionSyntax();
-    this->tryToAutoMatchOptions();
 
-    _parsed_options_groups = CLIF::FStr::
-                      splitIfExist(_unparsed_cmdline, _active_options);
-
-    if (!this->validateMissingRequired()) {
+    _parsed_options_groups = CLIF::FStr::splitIf(_unparsed_cmdline,
+    [&](const std::string &s)
+    {
+        if (s.size() > 1) {
+            return s[0] == '-';
+        }
+        return false;
+    });
+    this->normalizeOptionGroups();
+    if (!this->validateUnknownOptions()) {
+    } else if (!this->validateMissingRequired()) {
     } else if (!this->validateDuplicateUnique()) {
     } else if (!this->validateArgumentsAmount()) {
     } else {

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -555,7 +555,7 @@ convert(const std::string &str, const std::type_index &type)
 void CLIF::FStrcov::
 registerBasicConverter(void)
 {
-    /// int converter.
+    /// 'int' converter.
     _converter_map
     [std::type_index(typeid(int))] = [](const std::string &s)
     {
@@ -572,7 +572,7 @@ registerBasicConverter(void)
         return std::any(value);
     };
 
-    /// float converter.
+    /// 'float' converter.
     _converter_map
     [std::type_index(typeid(float))] = [](const std::string &s)
     {
@@ -589,7 +589,7 @@ registerBasicConverter(void)
         return std::any(value);
     };
 
-    /// double converter.
+    /// 'double' converter.
     _converter_map
     [std::type_index(typeid(double))] = [](const std::string &s)
     {
@@ -606,7 +606,7 @@ registerBasicConverter(void)
         return std::any(value);
     };
 
-    /// bool converter.
+    /// 'bool' converter.
     _converter_map
     [std::type_index(typeid(bool))] = [](const std::string &s)
     {
@@ -624,7 +624,7 @@ registerBasicConverter(void)
         return std::any(value);
     };
 
-    /// char converter.
+    /// 'char' converter.
     _converter_map
     [std::type_index(typeid(char))] = [](const std::string &s)
     {
@@ -638,14 +638,14 @@ registerBasicConverter(void)
         return std::any(s[0]);
     };
 
-    /// const char* converter.
+    /// 'const char*' converter.
     _converter_map
     [std::type_index(typeid(const char*))] = [](const std::string &s)
     {
         return std::any(s.data());
     };
 
-    /// string converter.
+    /// 'string' converter.
     _converter_map
     [std::type_index(typeid(std::string))] = [](const std::string &s)
     {
@@ -658,7 +658,7 @@ registerBasicConverter(void)
 void CLIF::FStrcov::
 registerBasicContainer(void)
 {
-    /// vector<...> converter.
+    /// 'vector<...>' converter.
     this->registerContainer<std::vector<int>>();
     this->registerContainer<std::vector<float>>();
     this->registerContainer<std::vector<double>>();
@@ -667,7 +667,7 @@ registerBasicContainer(void)
     this->registerContainer<std::vector<const char*>>();
     this->registerContainer<std::vector<std::string>>();
 
-    /// deque<...> converter.
+    /// 'deque<...>' converter.
     this->registerContainer<std::deque<int>>();
     this->registerContainer<std::deque<float>>();
     this->registerContainer<std::deque<double>>();
@@ -676,7 +676,7 @@ registerBasicContainer(void)
     this->registerContainer<std::deque<const char*>>();
     this->registerContainer<std::deque<std::string>>();
 
-    /// list<...> converter.
+    /// 'list<...>' converter.
     this->registerContainer<std::list<int>>();
     this->registerContainer<std::list<float>>();
     this->registerContainer<std::list<double>>();
@@ -685,7 +685,7 @@ registerBasicContainer(void)
     this->registerContainer<std::list<const char*>>();
     this->registerContainer<std::list<std::string>>();
 
-    /// set<...> converter.
+    /// 'set<...>' converter.
     this->registerContainer<std::set<int>>();
     this->registerContainer<std::set<float>>();
     this->registerContainer<std::set<double>>();
@@ -1338,8 +1338,8 @@ parseAllOptions(void)
                 This consider the none options or optional arguments
                 in subcommand.
 
-                We accept the empty command line, and return true.
-                This will directly use the default value of options.
+                We accept the empty command line, and return true,
+                this will directly use the default value of options.
              */
             valid = true;
         }

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -978,7 +978,6 @@ generateGlobalHelp(const std::map<std::string, CLIF::Wrapper> &func_linkers)
 void CLIF::FParser::
 normalizeOptionGroupEquals(std::vector<std::string> &option_group)
 {
-    size_t i;
     std::vector<std::string> t_group;
 
     for (auto &section : option_group) {
@@ -1010,7 +1009,7 @@ normalizeOptionGroupEquals(std::vector<std::string> &option_group)
     as {"-o", "file"}.
  */
 void CLIF::FParser::
-normlizeShortOptionGroups(void)
+normalizeShortOptionGroups(void)
 {
     bool has_param;
     size_t i, j, opt_num, arg_num;
@@ -1063,7 +1062,7 @@ normalizeOptionGroups(void)
         if (group[0] == "--") break;
         this->normalizeOptionGroupEquals(group);
     }
-    this->normlizeShortOptionGroups();
+    this->normalizeShortOptionGroups();
 }
 
 bool CLIF::FParser::

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -22,7 +22,7 @@
 /**
     \file    : CLIF.cpp
     \brief   : Implementation of CLIF.
-    \version : 1.0.0
+    \version : 1.1.0
  */
 
 #include "CLIF.hpp"

--- a/src/CLIF/CLIF.cpp
+++ b/src/CLIF/CLIF.cpp
@@ -52,7 +52,7 @@ toLower(const std::string& str)
 {
     std::string res;
 
-    for (char c:str) res+=std::tolower(c);
+    for (char c : str) res += std::tolower(c);
 
     return res;
 }
@@ -62,7 +62,7 @@ toUpper(const std::string &str)
 {
     std::string res;
 
-    for (char c:str) res+=std::toupper(c);
+    for (char c : str) res += std::toupper(c);
 
     return res;
 }
@@ -72,7 +72,7 @@ onlyAlpha(const std::string &str)
 {
     std::string res;
 
-    for (char c:str) if (std::isalpha(c)) res+=c;
+    for (char c : str) if (std::isalpha(c)) res += c;
 
     return res;
 }
@@ -82,7 +82,7 @@ onlyAlNum(const std::string &str)
 {
     std::string res;
 
-    for (char c:str) if (std::isalnum(c)) res+=c;
+    for (char c : str) if (std::isalnum(c)) res += c;
 
     return res;
 }
@@ -721,24 +721,45 @@ FOption(const std::string &long_name,
     }
 }
 
+/**
+    \note :
+    This function will filter the given long name, and only keep the
+    alphanumeric characters, '-', and '_'.
+ */
 CLIF::FOption &CLIF::FOption::
 longName(const std::string &long_name)
 {
-    if (long_name.find("--") == 0) {
-        _long_name = long_name;
-    } else {
-        _long_name = "--" + long_name;
+    std::string t_name;
+
+    for (char c : long_name) {
+        if (std::isalnum(c) || c == '-' || c == '_') {
+            t_name += c;
+        }
+    }
+
+    if (CLIF::FStr::onlyAlNum(t_name).size() >= 1) {
+        if (t_name.find("--") == 0) {
+            _long_name = t_name;
+        } else {
+            _long_name = "--" + t_name;
+        }
     }
     return *this;
 }
 
+/**
+   \note :
+   This function will find the first valid character, and then add "-"
+   to the front.
+
+   If can not find the valid character, this function will do nothing.
+ */
 CLIF::FOption &CLIF::FOption::
 shortName(const std::string &short_name)
 {
-    if (short_name.find("-") == 0) {
-        _short_name = short_name;
-    } else {
-        _short_name = "-" + short_name;
+    auto it = CLIF::FStr::onlyAlNum(short_name);
+    if (it.size() >= 1) {
+        _short_name = "-" + std::string(1, it[0]);
     }
     return *this;
 }

--- a/src/CLIF/CLIF.hpp
+++ b/src/CLIF/CLIF.hpp
@@ -82,23 +82,23 @@ namespace CLIF {
     ///////////////////////////////////////////////////////////////////////////
     ///// CLIF::OptType
     enum OptType {
-        PT_OPTIONAL = 0x00, ///< optional option type.
-        PT_REQUIRED = 0x01, ///< required option type.
-        PT_UNIQUEED = 0x02, ///< unique option type.
+        PT_OPTIONAL = 0x00, ///< Optional option type.
+        PT_REQUIRED = 0x01, ///< Required option type.
+        PT_UNIQUEED = 0x02, ///< Unique option type.
     };
 
     ///////////////////////////////////////////////////////////////////////////
     ///// CLIF::Color
     enum Color {
-        BLACK   = 0, ///< black color.
-        RED     = 1, ///< red color.
-        GREEN   = 2, ///< green color.
-        YELLOW  = 3, ///< yellow color.
-        BLUE    = 4, ///< blue color.
-        MAGENTA = 5, ///< magenta color.
-        CYAN    = 6, ///< cyan color.
-        WHITE   = 7, ///< white color.
-        DEFAULT = 9  ///< default color.
+        BLACK   = 0, ///< Black color.
+        RED     = 1, ///< Red color.
+        GREEN   = 2, ///< Green color.
+        YELLOW  = 3, ///< Yellow color.
+        BLUE    = 4, ///< Blue color.
+        MAGENTA = 5, ///< Magenta color.
+        CYAN    = 6, ///< Cyan color.
+        WHITE   = 7, ///< White color.
+        DEFAULT = 9  ///< Default color.
     };
     struct Wrapper;
 
@@ -117,11 +117,11 @@ namespace CLIF {
 ///////////////////////////////////////////////////////////////////////////////
 ///// CLIF::Wrapper
 struct CLIF::Wrapper {
-    std::string subcommand;       ///< subcommand name.
-    std::string description;      ///< subcommand description.
-    std::vector<FOption> options; ///< subcommand options.
+    std::string subcommand;       ///< Subcommand name.
+    std::string description;      ///< Subcommand description.
+    std::vector<FOption> options; ///< Subcommand options.
 
-    ///v subcommand trigger function.
+    ///v Subcommand trigger function.
     std::function<void(const std::vector<CLIF::FOption> &)> trigger_func;
 };
 
@@ -185,10 +185,10 @@ public:
 
     static void log(const std::string &msg, const int level);
 private:
-    static int  _log_level;            ///< log level.
-    static bool _is_log_file_ready;    ///< log file ready flag.
-    static std::string _log_file_path; ///< log file path.
-    static std::fstream _log_file;     ///< log file stream.
+    static int  _log_level;            ///< Log level.
+    static bool _is_log_file_ready;    ///< Log file ready flag.
+    static std::string _log_file_path; ///< Log file path.
+    static std::fstream _log_file;     ///< Log file stream.
 protected:
     static void parseDefaultPath(const char *argv);
     static void parsePath(int *argc, char *argv[], int &i);
@@ -260,7 +260,7 @@ public:
     {
         if (_converter_map.count(typeid(T))) {
             CLIF::FLog::
-            warnAt("CLIF::FStrcov::registerType",
+            warnAt("CLIF::FStrcov::registerNewBasic",
                 "Basic type converter '"
                 + std::string(typeid(T).name())
                 + "' is already registered.");
@@ -269,7 +269,7 @@ public:
         }
         _converter_map[std::type_index(typeid(T))] = func;
         CLIF::FLog::
-        infoAt("CLIF::FStrcov::registerType",
+        infoAt("CLIF::FStrcov::registerNewBasic",
             "New basic type converter '"
             + std::string(typeid(T).name())
             + "' successfully registered.");
@@ -516,10 +516,9 @@ public:
         } else if (_default_value.has_value() || _current_value.has_value()) {
             /**
                 If already exist value in default or current, this means the
-                data type is already decided
+                data type is already decided by the given value.
 
-                by the given value. So CLIF::FOption will not change data
-                type again.
+                So CLIF::FOption will not change data type again.
              */
         } else {
             _data_type = new_type;
@@ -577,16 +576,16 @@ public:
     inline std::any getDefaultValue(void) const
     { return _default_value; }
 private:
-    unsigned _option_type; ///< option type.
+    unsigned _option_type; ///< Option type.
 
-    std::type_index _data_type; ///< option data type.
-    std::string _long_name;     ///< option long name.
-    std::string _short_name;    ///< option short name.
-    std::string _help;          ///< option help.
-    std::any _default_value;    ///< option default value.
-    std::any _current_value;    ///< option current value.
+    std::type_index _data_type; ///< Option data type.
+    std::string _long_name;     ///< Option long name.
+    std::string _short_name;    ///< Option short name.
+    std::string _help;          ///< Option help.
+    std::any _default_value;    ///< Option default value.
+    std::any _current_value;    ///< Option current value.
 
-    std::function<bool(const std::any &)> _validator; ///< validator function.
+    std::function<bool(const std::any &)> _validator; ///< Validator function.
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/CLIF/CLIF.hpp
+++ b/src/CLIF/CLIF.hpp
@@ -161,6 +161,10 @@ public:
     splitKeyValue(const std::string &str, const std::string &delimiter);
 
     static std::vector<std::vector<std::string>>
+    splitIf(const std::vector<std::string> &vec,
+            const std::function<bool(const std::string &)> &condition);
+
+    static std::vector<std::vector<std::string>>
     splitIfExist(const std::vector<std::string> &vec,
                  const std::set<std::string> &check_set);
     static std::vector<std::vector<std::string>>
@@ -643,11 +647,13 @@ private:
     void generateSubCommandHelp(void);
     void generateGlobalHelp(const std::map<std::string, CLIF::Wrapper> &func_linkers);
 
-    /// Preprocess the input command line.
-    void tryToNormOptionSyntax(void);
-    void tryToAutoMatchOptions(void);
+    /// Normalize the processed command option groups.
+    void normalizeOptionGroupEquals(std::vector<std::string> &option_group);
+    void normlizeShortOptionGroups(void);
+    void normalizeOptionGroups(void);
 
     /// Validate the options.
+    bool validateUnknownOptions(void);
     bool validateMissingRequired(void);
     bool validateDuplicateUnique(void);
     bool validateArgumentsAmount(void);

--- a/src/CLIF/CLIF.hpp
+++ b/src/CLIF/CLIF.hpp
@@ -138,7 +138,8 @@ public:
     static std::string toUpper(const std::string &str);
     static std::string onlyAlpha(const std::string &str);
     static std::string onlyAlNum(const std::string &str);
-    static std::string join(const std::vector<std::string> &strs, const char *sign);
+    static std::string join(const std::vector<std::string> &strs,
+                            const char *sign);
 
     static std::vector<std::string>
     splitBy(const std::string &str, const char &delimiter);
@@ -146,9 +147,13 @@ public:
     splitBy(const std::string &str, const std::string &delimiter);
 
     static std::vector<std::string>
-    splitByBrackets(const std::string &str, const char &delimiter,bool strip = true);
+    splitByBrackets(const std::string &str,
+                    const char &delimiter,
+                    bool strip = true);
     static std::vector<std::string>
-    splitByBrackets(const std::string &str, const std::string &delimiter, bool strip = true);
+    splitByBrackets(const std::string &str,
+                    const std::string &delimiter,
+                    bool strip = true);
 
     static std::pair<std::string, std::string>
     splitKeyValue(const std::string &str, const char &delimiter);
@@ -156,14 +161,20 @@ public:
     splitKeyValue(const std::string &str, const std::string &delimiter);
 
     static std::vector<std::vector<std::string>>
-    splitIfExist(const std::vector<std::string> &vec, const std::set<std::string> &check_set);
+    splitIfExist(const std::vector<std::string> &vec,
+                 const std::set<std::string> &check_set);
     static std::vector<std::vector<std::string>>
-    splitIfExist(const std::vector<std::string> &vec, const std::unordered_set<std::string> &check_set);
+    splitIfExist(const std::vector<std::string> &vec,
+                 const std::unordered_set<std::string> &check_set);
     static std::vector<std::vector<std::string>>
-    splitIfExist(const std::vector<std::string> &vec, const std::vector<std::string> &check_vec);
+    splitIfExist(const std::vector<std::string> &vec,
+                 const std::vector<std::string> &check_vec);
 
     static std::string
-    formatByCols(const std::string &str1, const std::string &str2, const int columnL, const int columnR);
+    formatByCols(const std::string &str1,
+                 const std::string &str2,
+                 const int columnL,
+                 const int columnR);
 };
 
 

--- a/src/CLIF/CLIF.hpp
+++ b/src/CLIF/CLIF.hpp
@@ -649,7 +649,7 @@ private:
 
     /// Normalize the processed command option groups.
     void normalizeOptionGroupEquals(std::vector<std::string> &option_group);
-    void normlizeShortOptionGroups(void);
+    void normalizeShortOptionGroups(void);
     void normalizeOptionGroups(void);
 
     /// Validate the options.

--- a/src/CLIF/CLIF.hpp
+++ b/src/CLIF/CLIF.hpp
@@ -23,7 +23,7 @@
     \file    : CLIF.hpp
     \brief   : Header file of CLIF, including all declaration of CLIF classes,
                data types and functions.
-    \version : 1.0.0
+    \version : 1.1.0
  */
 
 #pragma once
@@ -59,7 +59,7 @@
 #endif
 
 /////////////////// _DEFINES_
-#define CLIF_VERSION                   "1.0.0"
+#define CLIF_VERSION                   "1.1.0"
 
 #define SPACE                          std::string(" ")
 

--- a/src/example/main.cpp
+++ b/src/example/main.cpp
@@ -7,7 +7,7 @@
     [INTRODUCTION]
 
         This is a functional CLI-Framework based on C/C++, which have features below:
-            a,  ingle File Dependency 
+            a,  ingle File Dependency
              :  Requires only the C++17 standard library with no external dependencies.
             b.  Functional Programming
              :  Direct function binding eliminates manual argument parsing.
@@ -42,12 +42,12 @@
 
         6.  Register user data type:
 
-                app.registerNewBasic<MyDataType>
+                app.registerBasicTypeConverter<MyDataType>
                 ([](const std::string &str){ ... } -> std::any);
 
         7.  Register container types (if needed):
 
-                app.registerNewContainer<vector<vector<int>>>();
+                app.registerContainerConverter<vector<vector<int>>>();
 
         8.  Start parsing:
 
@@ -57,7 +57,7 @@
 
         1.  Requires C++17 or higher : Framework heavily uses structured
                                        bindings and std::any.
-        2.  Container limits         : Pre-register nested containers 
+        2.  Container limits         : Pre-register nested containers
                                        using registerNewContainer<>().
         3.  Type safety              : Ensure function signatures exactly
                                        match option definitions.


### PR DESCRIPTION
### Changes Proposed
This PR introduces three key improvements to command-line argument parsing and ready for :

1. **Short option group normalization**  
   Implement RFC 0037-compliant behavior for grouped short options:
   - Splits `-XYZ` into individual flags (`-X`, `-Y`, `-Z`)
   - Distributes arguments sequentially:
     ```python
     {"-XY", "arg"}    → [("-X", "arg"), ("-Y",)]
     {"-XYZ", "a", "b"} → [("-X","a"), ("-Y","b"), ("-Z",)]
     ```
   - Explicitly *excludes* GNU-style attached arguments (`-ofile`→`-o file`)  
   See: `CLIF::FParser::normalizeShortOptionGroups`

2. **Option validation fixes**  
   - **Long options**: Auto-add `--` prefix if missing  
     `debug-mode` → `--debug-mode` | `--verbose` → `--verbose`
   - **Short options**: 
     - Use first alphanumeric character only  
     - Always format as single-dash prefixed  
       `v`→`-v` | `verbose`→`-v` | `--version`→`-v`
   - Unified validation: Require ≥1 alphanumeric char

3. **Equals sign parsing fix**  
   Correctly handle `-O=value` cases:
   ```diff
   - ["-O", "", "all"]  // incorrect
   + ["-O", "all"]      // fixed
   ```